### PR TITLE
Fix ValidationResult.join() to properly flatten error messages

### DIFF
--- a/app/validator/amount_validator.py
+++ b/app/validator/amount_validator.py
@@ -30,7 +30,7 @@ class ValidationResult:
     def join(cls, results: list['ValidationResult']) -> 'ValidationResult':
         if all(result.is_success for result in results):
             return cls.success()
-        error_messages = [result.error_messages for result in results if not result.is_success]
+        error_messages = [msg for result in results if not result.is_success for msg in result.error_messages]
         return cls(success=False, error_messages=error_messages)
 
     def raise_if_error(self):

--- a/app/validator/test_amount_validator.py
+++ b/app/validator/test_amount_validator.py
@@ -91,8 +91,8 @@ def test_join_some_successful_some_unsuccessful():
     joined = ValidationResult.join(results)
     assert joined.is_success is False
     assert len(joined.error_messages) == 2
-    assert ["First error"] in joined.error_messages
-    assert ["Second error"] in joined.error_messages
+    assert "First error" in joined.error_messages
+    assert "Second error" in joined.error_messages
 
 
 def test_join_all_unsuccessful():
@@ -104,9 +104,9 @@ def test_join_all_unsuccessful():
     joined = ValidationResult.join(results)
     assert joined.is_success is False
     assert len(joined.error_messages) == 3
-    assert ["Error 1"] in joined.error_messages
-    assert ["Error 2"] in joined.error_messages
-    assert ["Error 3"] in joined.error_messages
+    assert "Error 1" in joined.error_messages
+    assert "Error 2" in joined.error_messages
+    assert "Error 3" in joined.error_messages
 
 
 def test_join_empty_list():
@@ -127,7 +127,22 @@ def test_join_single_unsuccessful():
     results = [ValidationResult.error("Single error")]
     joined = ValidationResult.join(results)
     assert joined.is_success is False
-    assert ["Single error"] in joined.error_messages
+    assert "Single error" in joined.error_messages
+
+
+def test_joined_validation_result_can_raise_error():
+    """Test that joined validation results can be raised without TypeError."""
+    results = [
+        ValidationResult.error("First error"),
+        ValidationResult.error("Second error")
+    ]
+    joined = ValidationResult.join(results)
+    with pytest.raises(ValidationError) as exc_info:
+        joined.raise_if_error()
+    error_message = str(exc_info.value)
+    assert "Validation failed:" in error_message
+    assert "First error" in error_message
+    assert "Second error" in error_message
 
 
 def test_amount_validator_raises_on_too_large():


### PR DESCRIPTION
## Summary

Fixes a bug in `ValidationResult.join()` where error messages were not properly flattened.

## Changes

- Fix `ValidationResult.join()` to properly flatten error messages
- Update tests to expect flattened error messages